### PR TITLE
Add property enums for purpose, type, and status

### DIFF
--- a/app/Enums/PropertyPurpose.php
+++ b/app/Enums/PropertyPurpose.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum PropertyPurpose: string
+{
+    case Sale = 'sale';
+    case Rent = 'rent';
+}

--- a/app/Enums/PropertyStatus.php
+++ b/app/Enums/PropertyStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+enum PropertyStatus: string
+{
+    case Draft = 'draft';
+    case PendingReview = 'pending_review';
+    case Active = 'active';
+    case UnderOffer = 'under_offer';
+    case Reserved = 'reserved';
+    case Sold = 'sold';
+    case Leased = 'leased';
+    case Archived = 'archived';
+}

--- a/app/Enums/PropertyType.php
+++ b/app/Enums/PropertyType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum PropertyType: string
+{
+    case Apartment = 'apartment';
+    case House = 'house';
+    case Land = 'land';
+    case Commercial = 'commercial';
+    case Office = 'office';
+    case Villa = 'villa';
+}


### PR DESCRIPTION
## Summary
- define `PropertyPurpose` enum with sale and rent options
- add `PropertyType` enum for apartment, house, land, commercial, office, and villa
- include `PropertyStatus` enum to capture lifecycle states

## Testing
- `composer install` *(fails: curl error 56 while downloading packages)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9c053ef88328b28f0cb693f5528f